### PR TITLE
Replace deprecated `async_setup_platforms()` with `async_forward_entry_setups()`

### DIFF
--- a/custom_components/ontario_energy_board/__init__.py
+++ b/custom_components/ontario_energy_board/__init__.py
@@ -18,8 +18,7 @@ async def async_setup_entry(hass, entry: ConfigEntry):
     await coordinator.async_config_entry_first_refresh()
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
-
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 


### PR DESCRIPTION
change to using async_forward_entry_setups()