### PR TITLE
Bump holidays requirements version

### DIFF
--- a/custom_components/ontario_energy_board/manifest.json
+++ b/custom_components/ontario_energy_board/manifest.json
@@ -6,7 +6,7 @@
   "issue_tracker": "https://github.com/jrfernandes/ontario_energy_board/issues",
   "requirements": [
     "beautifulsoup4==4.10.0",
-    "holidays==0.12"
+    "holidays==0.21.3"
   ],
   "codeowners": [
     "@jrfernandes"


### PR DESCRIPTION
Home Assistant is unable to install integrations like workday with the current "holidays" requirement being set to 0.12, as it requires a more recent version.

I have bumped the version number locally, and everything still seems to work. Maybe if the author who is far more familiar with the code of this integration could look it over?

Mentioned also in Issue #29

Originally mentioned in https://github.com/home-assistant/core/issues/93508