### PR TITLE
Remove holidays from manifest.json

### DIFF
--- a/custom_components/ontario_energy_board/manifest.json
+++ b/custom_components/ontario_energy_board/manifest.json
@@ -5,8 +5,7 @@
   "documentation": "https://github.com/jrfernandes/ontario_energy_board",
   "issue_tracker": "https://github.com/jrfernandes/ontario_energy_board/issues",
   "requirements": [
-    "beautifulsoup4==4.10.0",
-    "holidays==0.12"
+    "beautifulsoup4==4.10.0"
   ],
   "codeowners": [
     "@jrfernandes"


### PR DESCRIPTION
Defer to the Home Assistant Core version of "holidays" instead

Resolves #28, #29