### PR TITLE
Support the ability to have two instances with the same energy company.

### DIFF
--- a/custom_components/ontario_energy_board/config_flow.py
+++ b/custom_components/ontario_energy_board/config_flow.py
@@ -25,9 +25,6 @@ class OntarioEnergyBoardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             energy_company = user_input[CONF_ENERGY_COMPANY]
             ulo_enabled = user_input[CONF_ULO_ENABLED]
 
-            await self.async_set_unique_id(energy_company)
-            self._abort_if_unique_id_configured()
-
             return self.async_create_entry(
                 title=energy_company,
                 data={

--- a/custom_components/ontario_energy_board/coordinator.py
+++ b/custom_components/ontario_energy_board/coordinator.py
@@ -37,7 +37,7 @@ class OntarioEnergyBoardDataUpdateCoordinator(DataUpdateCoordinator):
             update_method=self._async_update_data,
         )
         self.websession = async_get_clientsession(hass)
-        self.energy_company = self.config_entry.unique_id
+        self.energy_company = self.config_entry.data[CONF_ENERGY_COMPANY]
         self.ulo_enabled = self.config_entry.data[CONF_ULO_ENABLED]
         self.ontario_holidays = holidays.Canada(prov="ON", observed=True)
 


### PR DESCRIPTION
This removes the use of unique_id to track the energy company name such that more than one instance of the integration can be added at the same time (e.g., to be able to support the request in #43).