### PR TITLE
Update parameters to add August Civic Holiday

### DIFF
--- a/custom_components/ontario_energy_board/coordinator.py
+++ b/custom_components/ontario_energy_board/coordinator.py
@@ -39,7 +39,9 @@ class OntarioEnergyBoardDataUpdateCoordinator(DataUpdateCoordinator):
         self.websession = async_get_clientsession(hass)
         self.energy_company = self.config_entry.unique_id
         self.ulo_enabled = self.config_entry.data[CONF_ULO_ENABLED]
-        self.ontario_holidays = holidays.Canada(prov="ON", observed=True)
+        self.ontario_holidays = holidays.Canada(
+            prov="ON", observed=True, categories={"public", "optional"}
+        )
 
     @Throttle(REFRESH_RATES_INTERVAL)
     async def _async_update_data(self) -> None:

--- a/custom_components/ontario_energy_board/coordinator.py
+++ b/custom_components/ontario_energy_board/coordinator.py
@@ -40,7 +40,7 @@ class OntarioEnergyBoardDataUpdateCoordinator(DataUpdateCoordinator):
         self.energy_company = self.config_entry.unique_id
         self.ulo_enabled = self.config_entry.data[CONF_ULO_ENABLED]
         self.ontario_holidays = holidays.Canada(
-            prov="ON", observed=True, categories={"public", "optional"}
+            subdiv="ON", observed=True, categories={"public", "optional"}
         )
 
     @Throttle(REFRESH_RATES_INTERVAL)


### PR DESCRIPTION
The current call to holidays.Canada() will retrieve only the "public" holidays, which don't include the August Civic Holiday. Since the TOU rate for the Civic Holiday in Ontario is also charged as off-peak, it is necessary to add a parameter specifying both the "public" and "optional" categories to get the full list of 10 days considered [holidays](https://www.oeb.ca/consumer-information-and-protection/electricity-rates/holiday-schedule-time-use-and-ultra-low) by the OEB.